### PR TITLE
Add explicit minimum OS versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftyInsta",
+    platforms: [
+      .macOS(.v10_12), .iOS(.v9), .tvOS(.v9)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(


### PR DESCRIPTION
By default the minimum supported versions are "...the oldest deployment target version supported by the installed SDK for a given platform. One exception to this rule is macOS, for which the minimum deployment target version will start from 10.10" (extract from https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html). This conflicts with the latest version of CryptoSwift, which has 10_12 as minimum MacOS version.